### PR TITLE
If ExtractJwt.fromAuthHeaderAsBearerToken() is used, token must be pr…

### DIFF
--- a/routes/users.js
+++ b/routes/users.js
@@ -43,7 +43,7 @@ router.post('/authenticate', (req, res, next) => {
 
         res.json({
           success: true,
-          token: 'JWT '+token,
+          token: 'Bearer '+token,
           user: {
             id: user._id,
             name: user.name,


### PR DESCRIPTION
…efixed with 'Bearer' instead of 'JWT'.